### PR TITLE
fix wrong destination domain suffix with '.net'

### DIFF
--- a/pingparsing/_parser.py
+++ b/pingparsing/_parser.py
@@ -119,7 +119,9 @@ class PingParser(PingParserInterface):
         return (lines[stats_headline_idx], packet_info_line, body_line_list)
 
     def _parse_destination(self, stats_headline: str) -> str:
-        return stats_headline.lstrip("--- ").rstrip(" ping statistics ---")
+        start_len = len("--- ")
+        end_len = len(" ping statistics ---")
+        return stats_headline[start_len:-end_len]
 
     def __find_stats_headline_idx(self, lines: Sequence[str], re_stats_header: Pattern) -> int:
         for i, line in enumerate(lines):

--- a/test/test_pingparsing.py
+++ b/test/test_pingparsing.py
@@ -306,6 +306,30 @@ MACOS_UNREACHABLE_1 = PingTestData(
     },
     [],
 )
+MACOS_UNREACHABLE_2 = PingTestData(
+    dedent(
+        """\
+        PING example.net (93.184.216.34): 56 data bytes
+
+        --- example.net ping statistics ---
+        10 packets transmitted, 0 packets received, 100.0% packet loss
+        """
+    ),
+    {
+        "destination": "example.net",
+        "packet_transmit": 10,
+        "packet_receive": 0,
+        "packet_loss_count": 10,
+        "packet_loss_rate": 100.0,
+        "packet_duplicate_count": 0,
+        "packet_duplicate_rate": None,
+        "rtt_min": None,
+        "rtt_avg": None,
+        "rtt_max": None,
+        "rtt_mdev": None,
+    },
+    [],
+)
 MACOS_DUPLICATE_0 = PingTestData(
     dedent(
         """\
@@ -495,6 +519,7 @@ class Test_PingParsing_parse:
             [MACOS_SUCCESS_1, "macOS"],
             [MACOS_UNREACHABLE_0, "macOS"],
             [MACOS_UNREACHABLE_1, "macOS"],
+            [MACOS_UNREACHABLE_2, "macOS"],
             [MACOS_DUPLICATE_0, "macOS"],
             [ALPINE_LINUX_SUCCESS, "AlpineLinux"],
             [ALPINE_LINUX_DUP_LOSS, "AlpineLinux"],


### PR DESCRIPTION
**Issue:** pingparsing doesn't handle destination parsing with '.net' domain correctly

**Result and steps to appear:**

```bash
$ pingparsing example.net
{
    "example.net": {
        "destination": "example.ne",
        "packet_transmit": 10,
        "packet_receive": 10,
        "packet_loss_count": 0,
        "packet_loss_rate": 0.0,
        "rtt_min": 189.275,
        "rtt_avg": 266.611,
        "rtt_max": 327.308,
        "rtt_mdev": 42.726,
        "packet_duplicate_count": 0,
        "packet_duplicate_rate": 0.0
    }
}
```

**Expected result:** 

```diff
-        "destination": "example.ne",
+        "destination": "example.net",
```

The reason is that `strip()` in Python will remove all characters in function argument.

`_parse_destination` function tries to remove ` ping statistics ---`, but it removes `t` in `.net`, which is not expected.

Add a quick fix for that issue, hope it helps, thanks.